### PR TITLE
Track coverage with tox environments.

### DIFF
--- a/.tox-coveragerc
+++ b/.tox-coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+source =
+    hyperlink
+
+[paths]
+source =
+   ../hyperlink
+   */lib/python*/site-packages/hyperlink
+   pypy/site-packages/hyperlink

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,9 +40,10 @@ after_test:
 on_success:
     # Report coverage results to codecov.io
     # and export tox environment variables
+    - "%PYTHON%/Scripts/tox -e coverage-report"
     - "%PYTHON%/Scripts/pip install codecov"
     - set OS=WINDOWS
-    - "%PYTHON%/Scripts/codecov -e TOX_ENV OS"
+    - "%PYTHON%/Scripts/codecov -e TOX_ENV OS -f .tox\\coverage"
 
 artifacts:
   - path: dist\*

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,14 @@
 [tox]
-envlist = py26,py27,py34,pypy
+envlist = py26,py27,py34,pypy,coverage-report
 
 [testenv]
 changedir = .tox
 deps = -rrequirements-test.txt
-commands = py.test --doctest-modules {envsitepackagesdir}/hyperlink
+commands = coverage run --parallel --rcfile {toxinidir}/.tox-coveragerc -m pytest --doctest-modules {envsitepackagesdir}/hyperlink
+
+
+[testenv:coverage-report]
+changedir = .tox
+deps = coverage
+commands = coverage combine --rcfile {toxinidir}/.tox-coveragerc
+           coverage report --rcfile {toxinidir}/.tox-coveragerc


### PR DESCRIPTION
.tox-coveragerc tells coverage how to combine paths from within the
.tox directory.

See https://enotuniq.org/sourcing_your_source_without_src.html